### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Find out how to use the class in the documentation below:
 
 #### Installation:
 
-To use this class in your project, all you need to do is copy the files ALAnimationView.h and ALAnimationView.m. If you are using *Cocoapods* t is recommended that you add the 'ALAnimationView' pod into your Podfile. 
+To use this class in your project, all you need to do is copy the files ALAnimationView.h and ALAnimationView.m. If you are using *CocoaPods* t is recommended that you add the 'ALAnimationView' pod into your Podfile. 
 
 
 #### Using the class:


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
